### PR TITLE
Add Linux and macOS builds alongside the existing Windows build

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,7 +34,7 @@ The workflow consists of **4 jobs**:
 5. **Uploads artifact** - `GalaxyWizard-Linux` (30 days retention)
 
 #### Job 4: Build macOS Executable (requires test job to pass)
-1. **Sets up Python 3.11 on macOS** (Apple Silicon runner)
+1. **Sets up Python 3.11 on macOS** (`macos-latest` runner)
 2. **Installs Poetry**
 3. **Builds standalone binary** - Uses the same `main.spec` to create `GalaxyWizard`
 4. **Packages as tar.gz** - Preserves the executable permission bit

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ This workflow runs automatically on:
 
 ### What it does:
 
-The workflow consists of **2 jobs**:
+The workflow consists of **4 jobs**:
 
 #### Job 1: Test (Ubuntu)
 1. **Sets up Python 3.11** - Matches your development environment
@@ -25,6 +25,20 @@ The workflow consists of **2 jobs**:
 3. **Installs dependencies** - Including PyInstaller
 4. **Builds standalone .exe** - Uses `main.spec` to create `GalaxyWizard.exe`
 5. **Uploads artifact** - Executable available for download (30 days retention)
+
+#### Job 3: Build Linux Executable (requires test job to pass)
+1. **Sets up Python 3.11 on Ubuntu**
+2. **Installs Poetry** and OpenGL system libraries
+3. **Builds standalone binary** - Uses the same `main.spec` to create `GalaxyWizard`
+4. **Packages as tar.gz** - Preserves the executable permission bit
+5. **Uploads artifact** - `GalaxyWizard-Linux` (30 days retention)
+
+#### Job 4: Build macOS Executable (requires test job to pass)
+1. **Sets up Python 3.11 on macOS** (Apple Silicon runner)
+2. **Installs Poetry**
+3. **Builds standalone binary** - Uses the same `main.spec` to create `GalaxyWizard`
+4. **Packages as tar.gz** - Preserves the executable permission bit
+5. **Uploads artifact** - `GalaxyWizard-macOS` (30 days retention)
 
 ### Key differences from standard workflow:
 
@@ -52,8 +66,11 @@ After a successful workflow run:
 1. Go to the **Actions** tab in GitHub
 2. Click on the workflow run
 3. Scroll to **Artifacts** section
-4. Download `GalaxyWizard-Windows.zip`
+4. Download `GalaxyWizard-Windows`, `GalaxyWizard-Linux`, or `GalaxyWizard-macOS`
 5. Extract and run the standalone executable
+   - Linux/macOS: `tar -xzf GalaxyWizard-*.tar.gz && ./GalaxyWizard`
+   - macOS may block the unsigned binary on first launch; allow it under
+     System Settings → Privacy & Security, or run `xattr -d com.apple.quarantine GalaxyWizard`
 
 **Note:** Executables are kept for 30 days
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -113,3 +113,106 @@ jobs:
         name: GalaxyWizard-Windows
         path: dist/GalaxyWizard.exe
         retention-days: 30
+
+  build-linux:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Configure Poetry
+      run: |
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+
+    - name: Cache Poetry dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgl1-mesa-dev libglu1-mesa-dev
+
+    - name: Install dependencies
+      run: |
+        poetry install --no-interaction --no-ansi
+
+    - name: Build Linux executable
+      run: |
+        poetry run pyinstaller main.spec --clean --noconfirm
+
+    - name: Package Linux executable
+      # tar preserves the executable permission bit, which a plain
+      # artifact upload would strip
+      run: |
+        tar -czf GalaxyWizard-Linux.tar.gz -C dist GalaxyWizard
+
+    - name: Upload Linux executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: GalaxyWizard-Linux
+        path: GalaxyWizard-Linux.tar.gz
+        retention-days: 30
+
+  build-macos:
+    needs: test
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Configure Poetry
+      run: |
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+
+    - name: Cache Poetry dependencies
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Install dependencies
+      run: |
+        poetry install --no-interaction --no-ansi
+
+    - name: Build macOS executable
+      run: |
+        poetry run pyinstaller main.spec --clean --noconfirm
+
+    - name: Package macOS executable
+      # tar preserves the executable permission bit, which a plain
+      # artifact upload would strip
+      run: |
+        tar -czf GalaxyWizard-macOS.tar.gz -C dist GalaxyWizard
+
+    - name: Upload macOS executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: GalaxyWizard-macOS
+        path: GalaxyWizard-macOS.tar.gz
+        retention-days: 30

--- a/build_scripts.py
+++ b/build_scripts.py
@@ -21,8 +21,9 @@ def build_exe():
         result = subprocess.run(
             ["pyinstaller", "main.spec", "--clean"], check=True, capture_output=False
         )
+        exe_name = "GalaxyWizard.exe" if sys.platform == "win32" else "GalaxyWizard"
         print("\n✅ Build completed successfully!")
-        print("Executable location: dist/GalaxyWizard.exe")
+        print(f"Executable location: dist/{exe_name}")
         return result.returncode
     except subprocess.CalledProcessError as e:
         print(f"\n❌ Build failed with error: {e}")

--- a/main.spec
+++ b/main.spec
@@ -58,7 +58,7 @@ hiddenimports += collect_submodules('ai')
 # Note: Do not include 'test' as it conflicts with Python's built-in test package
 
 a = Analysis(
-    ['src\\main.py'],
+    [os.path.join('src', 'main.py')],
     pathex=['src'],  # Add src to the Python path
     binaries=[],
     datas=data_files,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ numpy = "==1.24.1"
 PyOpenGL = "==3.1.7"
 pygame = "^2.5.2"
 Twisted = "^24.3.0"
-PyOpenGL_accelerate = "==3.1.7"
+PyOpenGL_accelerate = ">=3.1.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
- Add build-linux and build-macos CI jobs that build standalone
  executables with PyInstaller from the same main.spec and upload
  them as tar.gz artifacts (tar preserves the executable bit)
- Make main.spec cross-platform by replacing the hardcoded
  Windows path 'src\main.py' with os.path.join
- Make build_scripts.py report the correct executable name per platform
- Document the new jobs and artifact downloads in the workflows README

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013mFawQm2wzmvmUMvcib3xJ